### PR TITLE
Command to run quick sql queries

### DIFF
--- a/laravel-bash-helpers.sh
+++ b/laravel-bash-helpers.sh
@@ -179,6 +179,10 @@ godb() {
     mysql "-u$DB_USERNAME" "-p$DB_PASSWORD" "$DB_HOST" "$DB_DATABASE" "$@"
 }
 
+query() {
+    godb -e "$@"
+}
+
 homestead() {
     ( cd ~/Homestead && vagrant "$@" )
 }


### PR DESCRIPTION
This fixes #5, because is using the current ```godb``` command to pass an additional parameter (-e) to execute queries

Example of usage
```~$: query "select * from users where expiration_date > curdate()"```